### PR TITLE
商品詳細ページのユーザー制限（編集機能）

### DIFF
--- a/app/assets/stylesheets/_item_edit.scss
+++ b/app/assets/stylesheets/_item_edit.scss
@@ -175,6 +175,7 @@
           border-radius: 5px;
           border: solid;
           font-weight: bold;
+          cursor: pointer;
         }
       }
       .back {

--- a/app/assets/stylesheets/_item_show.scss
+++ b/app/assets/stylesheets/_item_show.scss
@@ -105,6 +105,34 @@
   }
 }
 
+.r__itemManageBox{
+  padding: 24px 40px;
+  text-align: center;
+  background-color: #ffffff;
+  display: flex;
+  height: 148px;
+  align-items: center;
+  &__edit {
+    height: 52px;
+    width: 305px;
+    background-color: #3CCACE;
+    border: 1px solid #3CCACE;
+    color: #fff;
+    font-size: 16px;
+    line-height: 52px;
+  }
+  &__delete{
+    height: 52px;
+    width: 305px;
+    background-color: #3CCACE;
+    border: 1px solid #3CCACE;
+    color: #fff;
+    font-size: 16px;
+    margin-left: 10px;
+    line-height: 52px;
+  }
+}
+
 .k__itemChangeBox {
   padding: 24px 40px 40px;
   text-align: center;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,12 +9,23 @@ class ItemsController < ApplicationController
   end
 
   def edit  #事前に商品情報編集用アクションを定義
-    # @item = Item.find(params[:id])  
+    # @item = Item.find(params[:id])
   end
 
   def update  #事前に商品情報更新用アクションを定義
-    # item = Item.find(params[:id])
-    # item.update(item_params)
-    # redirect_to item_path(item.id)
+    # @item = Item.find(params[:id])
+    # if @item = Item.update(item_params)
+    #   redirect_to item_path, notice: "更新しました。"
+    # else
+    #   redirect_to edit_item_path, alert: "変更できません。入力必須項目を確認してください。"
+    # end
+
+
   end
+
+  private
+  #item_params ストロングパラメータ
+  # def item_params
+  #   params.require(:item).permit(:name, :description, :category_id, :brand_id, :price, :condition_id, :wait, :postage, :prefecture_id, :buyer_id, images_attributes: [:src, :_destroy, :id])
+  # end
 end

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -84,7 +84,7 @@
         .button
           %input(type="submit" name="exhibition" value="変更する" class="exhibition")
         .back
-          = link_to "キャンセル", "show" #仮置 本番は商品情報編集ページ遷移前のページに飛ぶ
+          = link_to "キャンセル", item_path #仮置 本番は商品情報編集ページ遷移前のページに飛ぶ
       .r__attention__container
         %p.message 禁止されている行為および出品物を必ずご確認ください。偽ブランド品や盗品物などの販売は犯罪であり、法律により処罰される可能性があります。 また、出品をもちまして加盟店規約に同意したことになります。
 

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -82,7 +82,7 @@
             %input(type="number" placeholder = "最低価格 ¥300" class= "price-box")
       .r__submit__container
         .button
-          %input(type="submit" name="exhibition" value="変更する" class="exhibition")
+          = f.submit "変更する", class: "exhibition"
         .back
           = link_to "キャンセル", item_path #仮置 本番は商品情報編集ページ遷移前のページに飛ぶ
       .r__attention__container
@@ -91,4 +91,4 @@
     .r__end__logo__container
       .r__end__logo__container__end__logo
         = link_to image_tag('logo.png', :width => '170', :height => '60'), root_path
-        %p ©️FURIMA.inc 
+        %p ©️FURIMA.inc

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -63,6 +63,11 @@
             %li.k__optionalBtn
               =icon('fa','flag')
               不適切な商品の通報
+      -# ユーザ制限機能(編集)の仮置 データ登録機能待ち
+      -# - if user_signed_in? && current_user.id == @item.user_id
+      .r__itemManageBox
+        = link_to "編集", "#", class: "r__itemManageBox__edit" #リンク先は未実装
+        = link_to "削除", "#", method: :delete, class: "r__itemManageBox__delete" #リンク先は未実装
 
       .k__itemChangeBox
         %ul.k__itemChangeBox__btnList

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -66,7 +66,7 @@
       -# ユーザ制限機能(編集)の仮置 データ登録機能待ち
       -# - if user_signed_in? && current_user.id == @item.user_id
       .r__itemManageBox
-        = link_to "編集", "#", class: "r__itemManageBox__edit" #リンク先は未実装
+        = link_to "編集", "items/edit", class: "r__itemManageBox__edit" #リンク先は未実装
         = link_to "削除", "#", method: :delete, class: "r__itemManageBox__delete" #リンク先は未実装
 
       .k__itemChangeBox

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -66,7 +66,7 @@
       -# ユーザ制限機能(編集)の仮置 データ登録機能待ち
       -# - if user_signed_in? && current_user.id == @item.user_id
       .r__itemManageBox
-        = link_to "編集", "items/edit", class: "r__itemManageBox__edit" #リンク先は未実装
+        = link_to "編集", edit_item_path, class: "r__itemManageBox__edit" #リンク先は未実装
         = link_to "削除", "#", method: :delete, class: "r__itemManageBox__delete" #リンク先は未実装
 
       .k__itemChangeBox

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,5 @@ Rails.application.routes.draw do
   end
   resources :credit_cards, only: [:new]
   resources :purchase, only: [:index]
-  get 'items/edit', to: 'items#edit' #商品情報編集ページへの遷移のため
   resources :items, only: [:index, :new, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
【サーバサイド】商品情報編集の実装における、商品詳細ページの編集及び削除ボタンの実装

# Why
商品詳細ページの編集及び削除ボタンのコーディングの確認のため。
ユーザー制限を設けた実装を踏まえてコーディングしていますが、現段階ではログイン機能が無いためユーザー制限がかかる部分はコメントアウトしています。

GyazoURL:
https://gyazo.com/315022afb7069805b9ae1eff2655eb52